### PR TITLE
Update AEM health check path to use shallow tag.

### DIFF
--- a/src/main/java/com/shinesolutions/aemorchestrator/service/AemInstanceHelperService.java
+++ b/src/main/java/com/shinesolutions/aemorchestrator/service/AemInstanceHelperService.java
@@ -119,7 +119,7 @@ public class AemInstanceHelperService {
      * @throws ClientProtocolException if there's an error in the HTTP protocol
      */
     public boolean isAuthorElbHealthy() throws ClientProtocolException, IOException {
-        String url = getAemUrlForAuthorElb() + "/system/health?tags=devops";
+        String url = getAemUrlForAuthorElb() + "/system/health?tags=shallow";
 
         return httpUtil.getHttpResponseCode(url) == HttpStatus.SC_OK;
     }


### PR DESCRIPTION
This is following aem-healthcheck upgrade to v1.3.1 (and newer), `devops` tag will be retired and should be replaced with `shallow` .
https://github.com/shinesolutions/aem-healthcheck/issues/10