### PR TITLE
Change SSL Verification of the AEM SSL certificate to false #51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added new COMPONENT_INIT_STATUS to instance tags
+- Add configuration to control the verification of the SSL Certificate when executing API calls to AEM #51
 
 ### Changed
 - Change default orchestrator and replicator credentials to overwrite-me/overwrite-me
 - Changed process of determining the healthy publish instance to check component init state instead of just AEM health
+- Change SSL Verification of the AEM SSL certificate to false #51
 
 ## [2.0.0] - unknown
 

--- a/src/main/java/com/shinesolutions/aemorchestrator/aem/AemApiFactory.java
+++ b/src/main/java/com/shinesolutions/aemorchestrator/aem/AemApiFactory.java
@@ -18,6 +18,10 @@ public class AemApiFactory {
     @Value("${aem.client.api.connection.timeout}")
     private Integer connectionTimeout;
     
+
+    @Value("${aem.client.api.verifyssl}")
+    private boolean verifySsl;
+
     @Resource
     private AemCredentials aemCredentials;
     
@@ -36,6 +40,7 @@ public class AemApiFactory {
     private ApiClient getApiClient(String basePath, UserType user) {
         ApiClient client = new ApiClient();
         
+        client.setVerifyingSsl(verifySsl);
         client.setBasePath(basePath);
         client.setDebugging(useDebug);
         client.setConnectTimeout(connectionTimeout);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -82,6 +82,7 @@ aem.port.authorDispatcher=80
 aem.port.author=80
 
 # Used when creating swaggeraem4j client
+aem.client.api.verifyssl=false
 aem.client.api.debug=false
 aem.client.api.connection.timeout=30000
 

--- a/src/test/java/com/shinesolutions/aemorchestrator/aem/AemApiFactoryTest.java
+++ b/src/test/java/com/shinesolutions/aemorchestrator/aem/AemApiFactoryTest.java
@@ -32,14 +32,19 @@ public class AemApiFactoryTest {
     
     private Boolean useDebug;
     
+    private Boolean verifySsl;
+
     @Before
     public void setup() {
         basePath = "testBasePath";
         useDebug = false;
+        verifySsl = false;
         connectionTimeout = 30000;
         
         setField(aemApiFactory, "useDebug", useDebug);
         setField(aemApiFactory, "connectionTimeout", connectionTimeout);
+        setField(aemApiFactory, "verifySsl", verifySsl);
+
     }
     
     @Test
@@ -53,6 +58,7 @@ public class AemApiFactoryTest {
         
         assertThat(result.getApiClient().getBasePath(), equalTo(basePath));
         assertThat(result.getApiClient().isDebugging(), is(useDebug));
+        assertThat(result.getApiClient().isVerifyingSsl(), is(verifySsl));
         assertThat(result.getApiClient().getConnectTimeout(), equalTo(connectionTimeout));
         
         HttpBasicAuth auth = (HttpBasicAuth) result.getApiClient().getAuthentication("aemAuth");
@@ -71,6 +77,7 @@ public class AemApiFactoryTest {
         
         assertThat(result.getApiClient().getBasePath(), equalTo(basePath));
         assertThat(result.getApiClient().isDebugging(), is(useDebug));
+        assertThat(result.getApiClient().isVerifyingSsl(), is(verifySsl));
         assertThat(result.getApiClient().getConnectTimeout(), equalTo(connectionTimeout));
         
         HttpBasicAuth auth = (HttpBasicAuth) result.getApiClient().getAuthentication("aemAuth");


### PR DESCRIPTION
### Added
- Add configuration to control the verification of the SSL Certificate when executing API calls to AEM #51

### Changed
- Change SSL Verification of the AEM SSL certificate to false #51

Prerequisite for PR https://github.com/shinesolutions/aem-aws-stack-builder/pull/418